### PR TITLE
Add scheduled notifications using Notification Triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Projekt je čistý statický web bez serverové logiky, takže ho lze snadno nas
 ## Nastavení notifikací
 
 - V sekci **Nastavení notifikací** zvolte preferovaný čas (formát 24 h) a klikněte na *Uložit nastavení*.
-- Aplikace každých 30 sekund kontroluje aktuální čas. Pokud se shoduje s nastaveným časem, pro každé uložené město vyhodnotí předpověď a zašle notifikaci. Za **koupací den** je považován den se slunečným počasím a maximální teplotou ≥ 25 °C bez výrazných srážek; za **deštivý den** se považuje den se srážkami ≥ 1 mm nebo pravděpodobností srážek nad 50 %.
-- Notifikace jsou zobrazeny pouze tehdy, pokud jste je v prohlížeči povolili. V některých prohlížečích (např. iOS Safari) mohou být notifikace omezené.
+- Aplikace se pokusí naplánovat notifikaci pomocí rozšíření **Notification Triggers** (dostupné především v prohlížeči Chrome na Androidu). Pokud toto rozšíření není k dispozici, provádí se kontrola každých 30&nbsp;sekund pouze při otevřené aplikaci.
+- Za **koupací den** je považován den se slunečným počasím a maximální teplotou ≥ 25 °C bez výrazných srážek; za **deštivý den** se považuje den se srážkami ≥ 1 mm nebo pravděpodobností srážek nad 50 %.
+- Notifikace jsou zobrazeny pouze tehdy, pokud jste je v prohlížeči povolili. V některých prohlížečích (zejména iOS Safari) nejsou notifikace na pozadí podporovány.
 
 ## Úprava kódu a přizpůsobení
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -67,3 +67,18 @@ self.addEventListener('message', (event) => {
     self.registration.showNotification(title, options);
   }
 });
+
+// Ošetření kliknutí na notifikaci – otevřít nebo zaměřit aplikaci
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if (client.url.includes('index.html') || client.url === '/' ) {
+          return client.focus();
+        }
+      }
+      return clients.openWindow('/');
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- schedule notifications using Notification Triggers when supported and fall back to the old interval check
- add helper to plan notification in advance
- handle notification clicks in the service worker
- document background notification limitation in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a73f9e8a083259e2f437eb053b0a1