### PR TITLE
Fix missing notification permission request

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,6 +57,9 @@ async function initApp() {
 
   // Naplánovat pravidelnou kontrolu pro zasílání notifikací
   scheduleDailyNotifications();
+
+  // Ihned po spuštění se pokusíme vyžádat povolení pro notifikace
+  requestNotificationPermission();
 }
 
 /**
@@ -571,6 +574,13 @@ function showNotification(title, options) {
     navigator.serviceWorker.controller.postMessage({ type: 'notify', title, options });
   } else if ('Notification' in window) {
     new Notification(title, options);
+  }
+}
+
+// Požádá uživatele o povolení notifikací, pokud ještě nebylo uděleno
+function requestNotificationPermission() {
+  if ('Notification' in window && Notification.permission === 'default') {
+    Notification.requestPermission();
   }
 }
 if (typeof module !== "undefined") {


### PR DESCRIPTION
## Summary
- request notification permission on startup if needed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a82a2364083258010eb49094be851