### PR TITLE
Implement Web Push setup for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Tento projekt je jednoduchá PWA aplikace v češtině, která využívá veřej
 | `index.html` | Hlavní webová stránka aplikace. |
 | `style.css` | Stylopis zajišťující responzivní a přehledné rozhraní. |
 | `app.js` | JavaScript s logikou aplikace – načítání dat, vyhledávání měst, ukládání do `localStorage` a plánování notifikací. |
-| `service-worker.js` | Service worker umožňující offline režim a zprostředkování notifikací. |
+| `sw.js` | Service worker umožňující offline režim a zprostředkování notifikací. |
 | `manifest.json` | Definuje parametry PWA (název, ikony, barvy, režim zobrazení). |
 | `icons/` | Obsahuje dvě ikony (`192×192` a `512×512`) generované jako abstraktní motiv. |
 | `README.md` | Tento návod. |
@@ -33,6 +33,8 @@ http://localhost:8000/weather-pwa/
 ```
 
 Po načtení stránky aplikace nabídne instalaci na domovskou obrazovku a požádá o povolení notifikací. Pokud aplikaci přidáte na plochu (Android/iOS) či spustíte jako samostatnou aplikaci v prohlížeči, bude nadále fungovat i bez připojení k internetu (pouze s uloženými daty).
+
+Od iOS 16.4 podporuje Safari standardní Web Push. Stačí aplikaci přidat na domovskou obrazovku, kliknout na tlačítko **Povolit notifikace** a po udělení oprávnění budou upozornění fungovat stejně jako u nativních aplikací.
 
 ## Spuštění serveru
 
@@ -55,7 +57,7 @@ Server poslouchá na portu `3000` a zároveň obsluhuje statické soubory aplika
 - V sekci **Nastavení notifikací** zvolte preferovaný čas (formát 24 h) a klikněte na *Uložit nastavení*.
 - Aplikace se pokusí naplánovat notifikaci pomocí rozšíření **Notification Triggers** (dostupné především v prohlížeči Chrome na Androidu). Pokud toto rozšíření není k dispozici, provádí se kontrola každých 30&nbsp;sekund pouze při otevřené aplikaci.
 - Za **koupací den** je považován den se slunečným počasím a maximální teplotou ≥ 25 °C bez výrazných srážek; za **deštivý den** se považuje den se srážkami ≥ 1 mm nebo pravděpodobností srážek nad 50 %.
-- Notifikace jsou zobrazeny pouze tehdy, pokud jste je v prohlížeči povolili. V některých prohlížečích (zejména iOS Safari) nejsou notifikace na pozadí podporovány.
+- Notifikace jsou zobrazeny pouze tehdy, pokud jste je v prohlížeči povolili. Od iOS 16.4 fungují i v Safari, pokud máte aplikaci přidanou na domovskou obrazovku.
 
 ## Úprava kódu a přizpůsobení
 

--- a/app.js
+++ b/app.js
@@ -29,12 +29,12 @@ function urlBase64ToUint8Array(base64String) {
 function registerServiceWorker() {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker
-      .register('service-worker.js')
-      .then(() => {
-        // Service worker úspěšně zaregistrován
+      .register('sw.js')
+      .then((reg) => {
+        console.log('SW registrován', reg);
       })
       .catch((err) => {
-        console.error('ServiceWorker registration failed:', err);
+        console.error('Chyba SW', err);
       });
   }
 }
@@ -74,7 +74,7 @@ async function initApp() {
   scheduleDailyNotifications();
 
   document
-    .getElementById('enable-notifications')
+    .getElementById('subscribeBtn')
     .addEventListener('click', handleEnableNotifications);
 }
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       <label for="notification-time">Čas upozornění:</label>
       <input id="notification-time" type="time" value="07:00" />
       <button id="save-settings">Uložit nastavení</button>
-      <button id="enable-notifications">Povolit notifikace</button>
+      <button id="subscribeBtn">Povolit notifikace</button>
       <p class="note">
         Upozornění na&nbsp;koupací den (🏖️) a&nbsp;déšť (🌧️) budou odeslány každý den
         v&nbsp;nastavený čas.

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,97 @@
+// Service Worker pro PWA aplikaci předpovědi počasí
+// Cachuje statické soubory pro offline použití a zprostředkovává zobrazení notifikací.
+
+const CACHE_NAME = 'weather-pwa-v1';
+
+// Seznam souborů, které se předem uloží do cache během instalace service workeru.
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/app.js',
+  '/manifest.json',
+  '/icons/icon-192.png',
+  '/icons/icon-512.png'
+];
+
+// Instalace: načtení a uložené statických souborů
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(PRECACHE_URLS);
+    })
+  );
+  // Okamžitě aktivovat nový service worker
+  self.skipWaiting();
+});
+
+// Aktivace: vyčištění starých cache (pokud verze změněna)
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames
+          .filter((cacheName) => cacheName !== CACHE_NAME)
+          .map((cacheName) => caches.delete(cacheName))
+      );
+    })
+  );
+  // Okamžitě převzít kontrolu nad klienty
+  self.clients.claim();
+});
+
+// Fetch handler: pokud je požadavek v cache, použijeme jej, jinak stáhneme ze sítě
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  // Odpovídáme pouze na GET dotazy
+  if (request.method !== 'GET') {
+    return;
+  }
+  event.respondWith(
+    caches.match(request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+      return fetch(request).catch(() => {
+        // Pokud síť selže, vrátíme základní stránku
+        return caches.match('/index.html');
+      });
+    })
+  );
+});
+
+// Příjem zpráv z hlavního skriptu pro zobrazování notifikací
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'notify') {
+    const { title, options } = event.data;
+    self.registration.showNotification(title, options);
+  }
+});
+
+// Přijetí push zprávy ze serveru
+self.addEventListener('push', (event) => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Nová notifikace';
+  const options = {
+    body: data.body,
+    icon: data.icon || 'icons/icon-192.png',
+    badge: data.badge || 'icons/icon-192.png',
+    data: data.url || '/'
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+// Ošetření kliknutí na notifikaci – otevřít nebo zaměřit aplikaci
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if (client.url.includes('index.html') || client.url === '/' ) {
+          return client.focus();
+        }
+      }
+      return clients.openWindow('/');
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- copy service worker to `sw.js` and use this entry point
- register the service worker using `sw.js`
- rename push button to `subscribeBtn`
- document iOS 16.4 push support and service worker filename

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b86733628832580e2a0226562cdd7