### PR TITLE
Improve forecast display and dark mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -328,9 +328,9 @@ async function fetchWeather(loc) {
         };
       });
 
-    // Podrobné úseky pro první dva dny
+    // Podrobné úseky pro první čtyři dny
     const segments = {};
-    const limit = Math.min(time.length, 48); // pouze 48 hodin
+    const limit = Math.min(time.length, 96); // první 96 hodin
     for (let i = 0; i < limit; i++) {
       const d = new Date(time[i]);
       const h = d.getHours();
@@ -353,7 +353,7 @@ async function fetchWeather(loc) {
     }
     const segmentsArray = Object.keys(segments)
       .sort()
-      .slice(0, 2)
+      .slice(0, 4)
       .map((dateStr) => ({ date: dateStr, ...segments[dateStr] }));
 
     const hourly = {
@@ -393,6 +393,17 @@ function createLocationCard(loc, weather) {
   });
   header.appendChild(removeBtn);
   card.appendChild(header);
+
+  const label = document.createElement('div');
+  label.className = 'chart-label';
+  const first = weather.hourly.time[0];
+  if (first) {
+    const d = new Date(first);
+    label.textContent = `Dnes (${d.toLocaleDateString('cs-CZ')})`;
+  } else {
+    label.textContent = 'Dnes';
+  }
+  card.appendChild(label);
 
   const chart = document.createElement('canvas');
   chart.className = 'hourly-chart';
@@ -435,7 +446,7 @@ function createLocationCard(loc, weather) {
     const tempP = document.createElement('div');
     tempP.textContent = `${Math.round(day.tempMax)}° / ${Math.round(day.tempMin)}°`;
     dayDiv.appendChild(tempP);
-    if (idx < 2 && segments[day.date]) {
+    if (idx < 4 && segments[day.date]) {
       ['night', 'morning', 'day'].forEach((part) => {
         const seg = document.createElement('div');
         seg.className = 'segment';

--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
     <!-- Ikony pro různé platformy -->
     <link rel="icon" type="image/png" sizes="192x192" href="icons/icon-192.png" />
     <link rel="apple-touch-icon" href="icons/icon-512.png" />
+    <!-- Písmo -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <!-- Hlavní styl -->
     <link rel="stylesheet" href="style.css" />
   </head>

--- a/style.css
+++ b/style.css
@@ -4,12 +4,18 @@
  */
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
-  background: linear-gradient(#0a84ff, #5ac8fa);
-  color: #fff;
+  background: #fff;
+  color: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #000;
+    color: #fff;
+  }
 }
 
 header {
@@ -116,8 +122,8 @@ main {
 }
 
 .forecast-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 0.5rem;
   margin-top: 0.5rem;
 }
@@ -211,6 +217,12 @@ button:hover {
   gap: 1rem;
   margin: 0.25rem 0 0.5rem;
   font-size: 0.8rem;
+}
+
+.chart-label {
+  text-align: center;
+  font-size: 0.9rem;
+  margin: 0.25rem 0;
 }
 
 .chart-legend .legend-item {


### PR DESCRIPTION
## Summary
- add Poppins font and use it across the app
- adjust layout so forecast days are stacked vertically
- show chart label for today's date
- compute segments for four days instead of two
- support dark mode backgrounds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b8c456a8083258f07bc5473e8dbec