### PR TITLE
Simplify notification system: daily time-based rules + test notification

### DIFF
--- a/app.js
+++ b/app.js
@@ -955,17 +955,17 @@ const PRESETS = [
   {
     name: 'Déšť',
     conditions: [{ param: 'precipitation_probability', op: '>=', value: 50 }],
-    logic: 'AND', timeHorizon: 2, consecutiveHours: null, cooldownMinutes: 180
+    logic: 'AND', notifyAt: '09:00', consecutiveHours: null
   },
   {
     name: 'Mráz',
     conditions: [{ param: 'temperature_2m', op: '<', value: 0 }],
-    logic: 'AND', timeHorizon: 24, consecutiveHours: null, cooldownMinutes: 720
+    logic: 'AND', notifyAt: '07:00', consecutiveHours: null
   },
   {
     name: 'Silný vítr',
     conditions: [{ param: 'wind_speed_10m', op: '>', value: 50 }],
-    logic: 'AND', timeHorizon: 12, consecutiveHours: null, cooldownMinutes: 360
+    logic: 'AND', notifyAt: '08:00', consecutiveHours: null
   },
   {
     name: 'Koupání',
@@ -973,7 +973,7 @@ const PRESETS = [
       { param: 'weather_code', op: 'in', value: [0, 1, 2] },
       { param: 'temperature_2m', op: '>', value: 25 }
     ],
-    logic: 'AND', timeHorizon: 24, consecutiveHours: 4, cooldownMinutes: 720
+    logic: 'AND', notifyAt: '09:00', consecutiveHours: 3
   }
 ];
 
@@ -990,7 +990,19 @@ function saveRules(rules) {
 }
 
 function getRulesForLocation(loc) {
-  return getStoredRules()[locKey(loc)] || [];
+  const rules = getStoredRules()[locKey(loc)] || [];
+  // Migrate old rules: add notifyAt, remove timeHorizon/cooldownMinutes
+  let needsSave = false;
+  rules.forEach((r) => {
+    if (!r.notifyAt) {
+      r.notifyAt = '09:00';
+      delete r.timeHorizon;
+      delete r.cooldownMinutes;
+      needsSave = true;
+    }
+  });
+  if (needsSave) setRulesForLocation(loc, rules);
+  return rules;
 }
 
 function setRulesForLocation(loc, rules) {
@@ -1095,6 +1107,7 @@ function renderNotificationOverlay() {
         <span class="toggle-slider"></span>
       </label>
     </div>
+    <button class="test-notif-btn" id="test-notif-btn" ${isSubscribed ? '' : 'disabled'}>Odeslat testovací notifikaci (30s)</button>
   `;
 
   if (locations.length === 0) {
@@ -1137,6 +1150,28 @@ function renderNotificationOverlay() {
     renderNotificationOverlay();
   });
 
+  document.getElementById('test-notif-btn').addEventListener('click', async () => {
+    if (!pushSubscription) return;
+    const btn = document.getElementById('test-notif-btn');
+    btn.disabled = true;
+    btn.textContent = 'Odesílám…';
+    try {
+      await fetch('/api/test-notification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subscription: pushSubscription, delaySeconds: 30 })
+      });
+      btn.textContent = 'Odesláno! Notifikace přijde za 30s';
+      setTimeout(() => {
+        btn.textContent = 'Odeslat testovací notifikaci (30s)';
+        btn.disabled = false;
+      }, 5000);
+    } catch (err) {
+      btn.textContent = 'Chyba při odesílání';
+      btn.disabled = false;
+    }
+  });
+
   inner.querySelectorAll('.preset-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
       const pi = parseInt(btn.dataset.preset);
@@ -1150,9 +1185,8 @@ function renderNotificationOverlay() {
         name: preset.name,
         conditions: JSON.parse(JSON.stringify(preset.conditions)),
         logic: preset.logic,
-        timeHorizon: preset.timeHorizon,
-        consecutiveHours: preset.consecutiveHours,
-        cooldownMinutes: preset.cooldownMinutes
+        notifyAt: preset.notifyAt,
+        consecutiveHours: preset.consecutiveHours
       };
       const rules = getRulesForLocation(loc);
       rules.push(rule);
@@ -1249,13 +1283,13 @@ function generateRuleSummary(rule) {
   });
   let text = parts.join(rule.logic === 'OR' ? ' nebo ' : ' a ');
   if (rule.consecutiveHours) text += ` · ${rule.consecutiveHours}h v kuse`;
-  text += ` · příštích ${rule.timeHorizon || 24}h`;
+  text += ` · denně v ${rule.notifyAt || '09:00'}`;
   return text;
 }
 
 /* ---- Rule Editor ---- */
 
-let editorState = { conditions: [], logic: 'AND', timeHorizon: 24, consecutiveHours: null, cooldownMinutes: 360 };
+let editorState = { conditions: [], logic: 'AND', notifyAt: '09:00', consecutiveHours: null };
 
 function openRuleEditor(loc, existingRule) {
   const inner = document.querySelector('.notification-overlay-inner');
@@ -1267,9 +1301,8 @@ function openRuleEditor(loc, existingRule) {
       name: existingRule.name || '',
       conditions: JSON.parse(JSON.stringify(existingRule.conditions)),
       logic: existingRule.logic || 'AND',
-      timeHorizon: existingRule.timeHorizon || 24,
-      consecutiveHours: existingRule.consecutiveHours || null,
-      cooldownMinutes: existingRule.cooldownMinutes || 360
+      notifyAt: existingRule.notifyAt || '09:00',
+      consecutiveHours: existingRule.consecutiveHours || null
     };
   } else {
     editorState = {
@@ -1277,9 +1310,8 @@ function openRuleEditor(loc, existingRule) {
       name: '',
       conditions: [{ param: 'temperature_2m', op: '>', value: 25 }],
       logic: 'AND',
-      timeHorizon: 24,
-      consecutiveHours: null,
-      cooldownMinutes: 360
+      notifyAt: '09:00',
+      consecutiveHours: null
     };
   }
 
@@ -1300,12 +1332,8 @@ function renderRuleEditor(container, loc, lk) {
         <button class="add-condition-btn" id="add-condition-btn">+ Přidat podmínku</button>
       </div>
       <div class="rule-field">
-        <div class="rule-field-label">Časový horizont</div>
-        <div class="stepper">
-          <button class="stepper-btn" id="horizon-minus">−</button>
-          <span class="stepper-value" id="horizon-value">${editorState.timeHorizon}h</span>
-          <button class="stepper-btn" id="horizon-plus">+</button>
-        </div>
+        <div class="rule-field-label">Čas odeslání</div>
+        <input type="time" id="notify-at-input" value="${editorState.notifyAt}">
       </div>
       <div class="rule-field">
         <div class="inline-toggle">
@@ -1323,12 +1351,6 @@ function renderRuleEditor(container, loc, lk) {
           </div>
         </div>
       </div>
-      <div class="rule-field">
-        <div class="rule-field-label">Cooldown (min. interval mezi upozorněními)</div>
-        <select id="cooldown-select">
-          ${[60,180,360,720,1440].map((m) => `<option value="${m}" ${editorState.cooldownMinutes === m ? 'selected' : ''}>${m < 60 ? m + ' min' : (m / 60) + 'h'}</option>`).join('')}
-        </select>
-      </div>
       <div class="editor-buttons">
         <button class="editor-btn secondary" id="editor-cancel">Zrušit</button>
         <button class="editor-btn primary" id="editor-save">Uložit</button>
@@ -1344,7 +1366,7 @@ function renderRuleEditor(container, loc, lk) {
 
   document.getElementById('editor-save').addEventListener('click', () => {
     editorState.name = document.getElementById('rule-name-input').value.trim() || autoName(editorState);
-    editorState.cooldownMinutes = parseInt(document.getElementById('cooldown-select').value);
+    editorState.notifyAt = document.getElementById('notify-at-input').value || '09:00';
 
     const rule = {
       id: editorState.id || 'r_' + Date.now(),
@@ -1352,9 +1374,8 @@ function renderRuleEditor(container, loc, lk) {
       name: editorState.name,
       conditions: editorState.conditions,
       logic: editorState.logic,
-      timeHorizon: editorState.timeHorizon,
-      consecutiveHours: editorState.consecutiveHours,
-      cooldownMinutes: editorState.cooldownMinutes
+      notifyAt: editorState.notifyAt,
+      consecutiveHours: editorState.consecutiveHours
     };
 
     const rules = getRulesForLocation(loc);
@@ -1372,16 +1393,6 @@ function renderRuleEditor(container, loc, lk) {
   document.getElementById('add-condition-btn').addEventListener('click', () => {
     editorState.conditions.push({ param: 'temperature_2m', op: '>', value: 25 });
     renderConditionRows();
-  });
-
-  // Horizon stepper
-  document.getElementById('horizon-minus').addEventListener('click', () => {
-    editorState.timeHorizon = Math.max(1, editorState.timeHorizon - (editorState.timeHorizon > 24 ? 12 : editorState.timeHorizon > 6 ? 6 : 1));
-    document.getElementById('horizon-value').textContent = editorState.timeHorizon + 'h';
-  });
-  document.getElementById('horizon-plus').addEventListener('click', () => {
-    editorState.timeHorizon = Math.min(168, editorState.timeHorizon + (editorState.timeHorizon >= 24 ? 12 : editorState.timeHorizon >= 6 ? 6 : 1));
-    document.getElementById('horizon-value').textContent = editorState.timeHorizon + 'h';
   });
 
   // Consecutive toggle & stepper

--- a/server.js
+++ b/server.js
@@ -78,6 +78,29 @@ app.get('/api/vapid-key', (_req, res) => {
   res.json({ key: VAPID_PUBLIC_KEY });
 });
 
+/* ---- Test Notification ---- */
+
+app.post('/api/test-notification', (req, res) => {
+  const { subscription, delaySeconds } = req.body || {};
+  if (!subscription) return res.status(400).json({ error: 'No subscription' });
+  const delay = Math.min(Math.max(parseInt(delaySeconds) || 30, 5), 300);
+  setTimeout(async () => {
+    try {
+      const payload = JSON.stringify({
+        title: 'Testovací notifikace',
+        body: `Push notifikace fungují správně! (zpoždění ${delay}s)`,
+        icon: 'icons/icon-192.png',
+        badge: 'icons/icon-192.png'
+      });
+      await webpush.sendNotification(subscription, payload);
+      console.log('Test notification sent');
+    } catch (err) {
+      console.error('Test notification failed:', err.message);
+    }
+  }, delay * 1000);
+  res.json({ success: true, delaySeconds: delay });
+});
+
 /* ---- Weather Fetch (server-side, for rule evaluation) ---- */
 
 const weatherServerCache = new Map();
@@ -144,24 +167,34 @@ function evaluateCondition(condition, hourData) {
   }
 }
 
+function getTodayDateString() {
+  return new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Prague' });
+}
+
 function evaluateRule(rule, hourlyData) {
   if (!rule.enabled || !rule.conditions || rule.conditions.length === 0) {
     return { triggered: false };
   }
 
-  const horizon = Math.min(rule.timeHorizon || 24, hourlyData.length);
-  const windowData = hourlyData.slice(0, horizon);
+  // Filter to today's hours (Europe/Prague timezone, matching Open-Meteo output)
+  const today = getTodayDateString(); // "YYYY-MM-DD"
+  const nowPrague = new Date().toLocaleString('sv-SE', { timeZone: 'Europe/Prague' }).slice(0, 16); // "YYYY-MM-DD HH:MM"
+  const nowCompare = nowPrague.replace(' ', 'T');
+  const todayData = hourlyData.filter((h) => {
+    return h.time && h.time.startsWith(today) && h.time >= nowCompare;
+  });
+
+  if (todayData.length === 0) return { triggered: false };
 
   // For each hour, check if all/any conditions match
   const logic = rule.logic || 'AND';
-  const hourMatches = windowData.map((hourData) => {
+  const hourMatches = todayData.map((hourData) => {
     const results = rule.conditions.map((c) => evaluateCondition(c, hourData));
     return logic === 'AND' ? results.every(Boolean) : results.some(Boolean);
   });
 
   const consecutive = rule.consecutiveHours;
   if (consecutive && consecutive > 1) {
-    // Find N consecutive matching hours
     let count = 0;
     for (const match of hourMatches) {
       if (match) {
@@ -174,23 +207,19 @@ function evaluateRule(rule, hourlyData) {
     return { triggered: false };
   }
 
-  // Any single hour match triggers
   return { triggered: hourMatches.some(Boolean) };
 }
 
-/* ---- Cooldown Tracking ---- */
+/* ---- Sent-Today Tracking ---- */
 
-const cooldowns = new Map(); // ruleId -> timestamp
+const sentToday = new Map(); // ruleId -> "YYYY-MM-DD"
 
-function isCoolingDown(ruleId, cooldownMinutes) {
-  if (!cooldownMinutes) return false;
-  const last = cooldowns.get(ruleId);
-  if (!last) return false;
-  return Date.now() - last < cooldownMinutes * 60 * 1000;
+function alreadySentToday(ruleId) {
+  return sentToday.get(ruleId) === getTodayDateString();
 }
 
-function markTriggered(ruleId) {
-  cooldowns.set(ruleId, Date.now());
+function markSentToday(ruleId) {
+  sentToday.set(ruleId, getTodayDateString());
 }
 
 /* ---- Rule Summary for Notification Body ---- */
@@ -224,25 +253,35 @@ function buildNotificationBody(rule) {
   });
   let text = parts.join(rule.logic === 'OR' ? ' nebo ' : ' a ');
   if (rule.consecutiveHours) text += ` po dobu ${rule.consecutiveHours}h`;
-  text += ` (příštích ${rule.timeHorizon || 24}h)`;
+  text += ' (dnes)';
   return text;
 }
 
 /* ---- Scheduling Loop ---- */
 
+function getCurrentPragueTime() {
+  return new Date().toLocaleTimeString('cs-CZ', {
+    timeZone: 'Europe/Prague', hour: '2-digit', minute: '2-digit', hour12: false
+  });
+}
+
 async function checkAllSubscriptions() {
-  for (const sub of subscriptions) {
+  const currentTime = getCurrentPragueTime(); // "HH:MM"
+
+  for (const sub of [...subscriptions]) {
     for (const loc of (sub.locations || [])) {
       for (const rule of (loc.rules || [])) {
         if (!rule.enabled) continue;
-        if (isCoolingDown(rule.id, rule.cooldownMinutes)) continue;
+        const notifyAt = rule.notifyAt || '09:00';
+        if (notifyAt !== currentTime) continue;
+        if (alreadySentToday(rule.id)) continue;
 
         try {
           const hourly = await fetchWeatherForRules(loc);
           const result = evaluateRule(rule, hourly);
 
           if (result.triggered) {
-            markTriggered(rule.id);
+            markSentToday(rule.id);
             const payload = JSON.stringify({
               title: `${loc.name}: ${rule.name || 'Upozornění'}`,
               body: buildNotificationBody(rule),
@@ -251,15 +290,14 @@ async function checkAllSubscriptions() {
             });
             try {
               await webpush.sendNotification(sub.subscription, payload);
-              console.log(`Notification sent: ${loc.name} - ${rule.name}`);
+              console.log(`Notification sent: ${loc.name} - ${rule.name} (${notifyAt})`);
             } catch (pushErr) {
               console.error('Push failed:', pushErr.message);
-              // Remove invalid subscriptions (410 Gone)
               if (pushErr.statusCode === 410) {
                 const idx = subscriptions.indexOf(sub);
                 if (idx !== -1) subscriptions.splice(idx, 1);
                 saveSubscriptionsToDisk();
-                return; // Skip rest of this subscription
+                break;
               }
             }
           }
@@ -271,15 +309,10 @@ async function checkAllSubscriptions() {
   }
 }
 
-// Check every 5 minutes
+// Check every minute
 setInterval(() => {
   checkAllSubscriptions().catch((e) => console.error('Check error:', e));
-}, 5 * 60 * 1000);
-
-// Also check shortly after startup
-setTimeout(() => {
-  checkAllSubscriptions().catch((e) => console.error('Initial check error:', e));
-}, 30 * 1000);
+}, 60 * 1000);
 
 app.use(express.static(__dirname));
 

--- a/style.css
+++ b/style.css
@@ -965,6 +965,29 @@ body {
   margin-top: 2px;
 }
 
+.test-notif-btn {
+  width: 100%;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 0.5px solid var(--glass-border);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.88rem;
+  cursor: pointer;
+  margin-bottom: 16px;
+  transition: opacity 0.15s;
+}
+
+.test-notif-btn:active {
+  opacity: 0.7;
+}
+
+.test-notif-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
 /* iOS-style toggle switch */
 .toggle-switch {
   position: relative;
@@ -1168,6 +1191,7 @@ body {
 
 .rule-field input[type="text"],
 .rule-field input[type="number"],
+.rule-field input[type="time"],
 .rule-field select {
   width: 100%;
   padding: 10px 12px;

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 // Service Worker pro PWA aplikaci předpovědi počasí
 // Cachuje statické soubory pro offline použití a zprostředkovává zobrazení notifikací.
 
-const CACHE_NAME = 'weather-pwa-v2';
+const CACHE_NAME = 'weather-pwa-v3';
 
 // Seznam souborů, které se předem uloží do cache během instalace service workeru.
 const PRECACHE_URLS = [


### PR DESCRIPTION
Replace complex cooldown/horizon system with simple daily scheduling:
- Each rule now has a notifyAt time (e.g. "09:00") instead of timeHorizon and cooldownMinutes
- Server evaluates rules once daily at the specified time against today's forecast
- Add test notification endpoint and UI button (sends push after 30s delay)
- Migrate existing rules automatically (default notifyAt: "09:00")
- Update presets: Rain 9:00, Frost 7:00, Wind 8:00, Swimming 9:00
- Bump service worker cache to v3

https://claude.ai/code/session_01HrAQhrfneSWgUHpzXAmJfh